### PR TITLE
Add zaza functional testing

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,7 @@ tags:
     - misc
 series:
     - bionic
+    - xenial
 # -- example relations, delete if unneeded
 #requires:
 #    db:

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,50 +33,82 @@ class ${class}(CharmBase):
     def __init__(self, *args):
         """Initialize charm and configure states and events to observe."""
         super().__init__(*args)
-        self.unit = self.framework.model.unit
         # -- standard hook observation
-        self.framework.observe(self.on.start, self)
-        self.framework.observe(self.on.config_changed, self)
+        self.framework.observe(self.on.install, self.on_install)
+        self.framework.observe(self.on.start, self.on_start)
+        self.framework.observe(self.on.config_changed, self.on_config_changed)
+        # -- initialize states --
+        self.state.set_default(installed=False)
+        self.state.set_default(configured=False)
+        self.state.set_default(started=False)
         # -- example action observation
-        self.framework.observe(self.on.example_action, self)
+        # self.framework.observe(self.on.example_action, self)
         # -- example relation / interface observation, disabled by default
         # self.framework.observe(self.on.db_relation_changed, self)
         # self.mysql = MySQLInterfaceRequires(self, 'db')
 
-    def on_start(self, event):
-        """Handle start state."""
-        # do things on start, like install packages
-        # once done, mark state as done
+    def on_install(self, event):
+        """Handle install state."""
         self.unit.status = MaintenanceStatus("Installing charm software")
-        # perform installation and common configuration bootstrap tasks
-        self.unit.status = MaintenanceStatus("Software installed, performing configuration")
-        self.state._started = True
+        # Perform install tasks
+        self.unit.status = MaintenanceStatus("Install complete")
+        self.model._backend.juju_log("INFO", "Install of software complete")
+        self.state.installed = True
 
     def on_config_changed(self, event):
-        """Handle config changed hook."""
-        # if software is installed and DB related, configure software
-        if self.state._started and self.state._db_configured:
-            # configure your software
-            self.example_config = self.model.config['example_config']
-            event.log("Install of software complete")
-            self.unit.status = ActiveStatus("Software installed and configured")
-            self.state._configured = True
-        elif self.state._started:
-            event.log("Waiting on configuration to run, and DB to be related.")
-            self.unit.status = BlockedStatus("Waiting for MySQL to be related")
-        else:
-            event.log("Waiting on installation to complete.")
+        """Handle config changed."""
+
+        if not self.state.installed:
+            self.model._backend.juju_log(
+                "ERROR", "Config changed called before install complete."
+            )
+            self.unit.status = MaintenanceStatus(
+                "Install not completed, not configuring."
+            )
+
+            return
+
+        if self.state.started:
+            # Stop if necessary for reconfig
+            self.model._backend.juju_log("INFO", "Stopping for configuration")
+            pass
+        # Configure the software
+        self.model._backend.juju_log("INFO", "Configuring")
+        self.state.configured = True
+
+    def on_start(self, event):
+        """Handle start state."""
+
+        if not self.state.configured:
+            self.model._backend.juju_log(
+                "ERROR", "Install called before configuration complete."
+            )
+
+            self.unit.status = MaintenanceStatus(
+                "Configure not completed, not starting."
+            )
+
+            return
+
+        self.unit.status = MaintenanceStatus("Starting charm software")
+        # Start software
+        self.unit.status = ActiveStatus("Unit is ready")
+        self.state.started = True
 
     # -- Example relation interface for MySQL, not observed by default:
-    def on_db_relation_changed(self, event):
-        """Handle an example db relation's change event."""
-        self.password = event.relation.data[event.unit].get("password")
-        self.unit.status = MaintenanceStatus("Configuring database")
-        if self.mysql.is_ready:
-            event.log("Database relation complete")
-        self.state._db_configured = True
+    # def on_db_relation_changed(self, event):
+    #     """Handle an example db relation's change event."""
+    #     self.password = event.relation.data[event.unit].get("password")
+    #     self.unit.status = MaintenanceStatus("Configuring database")
+    #     if self.mysql.is_ready:
+    #         event.log("Database relation complete")
+    #     self.state._db_configured = True
 
-    def on_example_action(self, event):
-        """Handle the example_action action."""
-        event.log("Hello from the example action.")
-        event.set_results({"success": "true"})
+    # def on_example_action(self, event):
+    #     """Handle the example_action action."""
+    #     event.log("Hello from the example action.")
+    #     event.set_results({"success": "true"})
+
+
+if __name__ == "__main__":
+    main(CloudstatsCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -111,4 +111,4 @@ class ${class}(CharmBase):
 
 
 if __name__ == "__main__":
-    main(CloudstatsCharm)
+    main(${class})

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ sys.path.append('lib')
 
 from ops.charm import CharmBase  # noqa:E402
 from ops.framework import StoredState  # noqa:E402
+from ops.main import main  # noqa:E402
 from ops.model import (  # noqa:E402
     ActiveStatus,
     BlockedStatus,

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza

--- a/tests/functional/tests/bundles/bionic.yaml
+++ b/tests/functional/tests/bundles/bionic.yaml
@@ -1,6 +1,6 @@
 series: bionic
 
 applications:
-    cloudstats:
+    ${metadata.package}:
         charm: ../../../../
         num_units: 1

--- a/tests/functional/tests/bundles/bionic.yaml
+++ b/tests/functional/tests/bundles/bionic.yaml
@@ -1,0 +1,6 @@
+series: bionic
+
+applications:
+    cloudstats:
+        charm: ../../../../
+        num_units: 1

--- a/tests/functional/tests/bundles/xenial.yaml
+++ b/tests/functional/tests/bundles/xenial.yaml
@@ -1,7 +1,7 @@
 series: xenial
 
 applications:
-    cloudstats:
+    ${metadata.package}:
         charm: ../../../../
         num_units: 1
 

--- a/tests/functional/tests/bundles/xenial.yaml
+++ b/tests/functional/tests/bundles/xenial.yaml
@@ -1,0 +1,7 @@
+series: xenial
+
+applications:
+    cloudstats:
+        charm: ../../../../
+        num_units: 1
+

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -1,0 +1,17 @@
+tests:
+# - bionic_model:
+#   - zaza.charm_tests.noop.tests.NoopTestBionic
+# - xenial_model:
+#   - zaza.charm_tests.noop.tests.NoopTestXenial
+ - zaza.charm_tests.noop.tests.NoopTest
+configure:
+# - bionic_model:
+#   - zaza.charm_tests.noop.setup.basic_setup_bionic
+# - xenial_model:
+#   - zaza.charm_tests.noop.setup.basic_setup_xenial
+ - zaza.charm_tests.noop.setup.basic_setup
+gate_bundles:
+    - xenial
+    - bionic
+smoke_bundles:
+    - focal

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,28 @@
+[tox]
+skipsdist = True
+envlist = unit, functional
+skip_missing_interpreters = True
+
+[testenv]
+basepython = python3
+setenv =
+  PYTHONPATH = {toxinidir}/lib/:{toxinidir}
+passenv = HOME
+
+[testenv:functional]
+changedir = {toxinidir}/tests/functional
+commands = functest-run-suite {posargs}
+deps = -r{toxinidir}/tests/functional/requirements.txt
+
+[testenv:lint]
+commands = flake8
+deps =
+    flake8
+    flake8-docstrings
+    flake8-import-order
+    pep8-naming
+    flake8-colors
+
 [flake8]
 exclude =
     .git,


### PR DESCRIPTION
This gets zaza doing a deploy of an 'empty' charm. Still have some comment lines to clean up and I haven't added things like an example action and a test of that action but this is a start.

There were a few fixes to get this to deploy with the charm itself, and I've added in storage to show checking state. I didn't split the charm changes from the test addition or I would have had a merge that added failing functional tests which didn't seem appropriate.