### PR TITLE
rm space in shebang

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #


### PR DESCRIPTION
Although space after `#!` in shebang is valid syntax, but it's uncommon. Remove the space to be consistent with common shebang.